### PR TITLE
Add extra_types, use NoneType from extra types

### DIFF
--- a/easy_llama/extra_types.py
+++ b/easy_llama/extra_types.py
@@ -1,0 +1,4 @@
+# extra_types.py
+# https://github.com/ddh0/easy-llama/
+
+NoneType = type(None)

--- a/easy_llama/model.py
+++ b/easy_llama/model.py
@@ -1,35 +1,37 @@
 # model.py
 # https://github.com/ddh0/easy-llama/
-from ._version import __version__, __llama_cpp_version__
+from ._version import __llama_cpp_version__, __version__
 
 """Submodule containing the Model class to work with language models"""
 
+import heapq
 import os
 import sys
-import heapq
+from typing import Generator, Optional, Union
+
 import numpy as np
-
-from .utils import (
-    _SupportsWriteAndFlush,
-    QuickGGUFReader,
-    print_warning,
-    print_verbose,
-    _print_debug,
-    assert_type,
-    softmax
-)
-
-from .samplers import SamplerSettings, DefaultSampling
 from llama_cpp import Llama, StoppingCriteriaList
-from typing    import Generator, Optional, Union
-from types     import NoneType
+
+from .extra_types import NoneType
+from .samplers import DefaultSampling, SamplerSettings
+from .utils import (
+    QuickGGUFReader,
+    _print_debug,
+    _SupportsWriteAndFlush,
+    assert_type,
+    print_verbose,
+    print_warning,
+    softmax,
+)
 
 
 class ModelUnloadedException(Exception):
     """Exception raised when trying to use a model that has been unloaded"""
+
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
 
 class Model:
     """
@@ -70,7 +72,7 @@ class Model:
         n_gpu_layers: int = 0,
         offload_kqv: bool = True,
         flash_attn: bool = False,
-        verbose: bool = False
+        verbose: bool = False,
     ):
         """
         Given the path to a GGUF file, construct a Model instance.
@@ -85,12 +87,12 @@ class Model:
         - verbose: Whether to print additional backend information
         """
 
-        assert_type(verbose, bool, 'verbose', 'Model')
+        assert_type(verbose, bool, "verbose", "Model")
         if verbose:
             print_verbose(f"easy_llama package version: {__version__}")
             print_verbose(f"llama_cpp package version: {__llama_cpp_version__}")
 
-        assert_type(model_path, str, 'model_path', 'Model')
+        assert_type(model_path, str, "model_path", "Model")
         if not os.path.exists(model_path):
             raise FileNotFoundError(
                 f"Model: the given model_path {model_path!r} does not exist"
@@ -100,11 +102,11 @@ class Model:
                 f"Model: the given model_path {model_path!r} is a directory, "
                 "not a GGUF file"
             )
-        assert_type(context_length, (int, NoneType), 'context_length', 'Model')
-        assert_type(n_gpu_layers, int, 'n_gpu_layers', 'Model')
-        assert_type(offload_kqv, bool, 'offload_kqv', 'Model')
-        assert_type(flash_attn, bool, 'flash_attn', 'Model')
-        
+        assert_type(context_length, (int, NoneType), "context_length", "Model")
+        assert_type(n_gpu_layers, int, "n_gpu_layers", "Model")
+        assert_type(offload_kqv, bool, "offload_kqv", "Model")
+        assert_type(flash_attn, bool, "flash_attn", "Model")
+
         # save __init__ parameters for __repr__
         self._model_path = model_path
         self._context_length = context_length
@@ -117,22 +119,19 @@ class Model:
         if isinstance(context_length, int) and context_length <= 0:
             context_length = None
 
-        if sys.byteorder == 'big':
+        if sys.byteorder == "big":
             print_warning(
-                "host is big-endian, please ensure your GGUF file is also "
-                "big-endian"
+                "host is big-endian, please ensure your GGUF file is also " "big-endian"
             )
-        elif sys.byteorder == 'little':
+        elif sys.byteorder == "little":
             if verbose:
-                print_verbose(
-                    "host is little-endian"
-                )
+                print_verbose("host is little-endian")
         else:
             print_warning(
                 f"unexpected value for sys.byteorder: {sys.byteorder!r}, "
                 "expected 'little' for little-endian or 'big' for big-endian"
             )
-        
+
         self._model_file_size_bytes = os.stat(model_path).st_size
         self.metadata = QuickGGUFReader.load_metadata(model_path)
 
@@ -143,25 +142,25 @@ class Model:
         ctx_quality_hint = None
 
         for key in self.metadata.keys():
-            if key.endswith('.context_length'):
+            if key.endswith(".context_length"):
                 n_ctx_train = int(self.metadata[key])
-            elif key.endswith('.rope.freq_base'):
+            elif key.endswith(".rope.freq_base"):
                 rope_freq_base_train = float(self.metadata[key])
-            elif key.endswith('.block_count'):
+            elif key.endswith(".block_count"):
                 n_layer = int(self.metadata[key])
 
         if n_ctx_train is None:
-            raise KeyError(
-                "GGUF file does not specify a context length"
-            )
-        
+            raise KeyError("GGUF file does not specify a context length")
+
         rope_freq_base = Model._calculate_rope_freq_base(
-            n_ctx_train,
-            context_length or n_ctx_train,
-            rope_freq_base_train
+            n_ctx_train, context_length or n_ctx_train, rope_freq_base_train
         )
 
-        if rope_freq_base_train is None or context_length is None or context_length <= n_ctx_train:
+        if (
+            rope_freq_base_train is None
+            or context_length is None
+            or context_length <= n_ctx_train
+        ):
             # no need to do context scaling, load model normally
 
             if context_length is None:
@@ -169,33 +168,31 @@ class Model:
                 ctx_scale = 1.0
             else:
                 self.context_length = context_length
-                ctx_scale = context_length/n_ctx_train
-            ctx_quality_hint = 'native'
+                ctx_scale = context_length / n_ctx_train
+            ctx_quality_hint = "native"
 
         elif context_length > n_ctx_train:
             # multiply rope_freq_base according to requested context length
             # because context length > n_ctx_train and rope freq base is known
 
             self.context_length = context_length
-            ctx_scale = context_length/n_ctx_train
+            ctx_scale = context_length / n_ctx_train
 
             if 1 < ctx_scale < 1.5:
-                ctx_quality_hint = 'great'
+                ctx_quality_hint = "great"
             elif 1.5 <= ctx_scale < 2:
-                ctx_quality_hint = 'good'
+                ctx_quality_hint = "good"
             elif 2 <= ctx_scale < 4:
-                ctx_quality_hint = 'fair'
+                ctx_quality_hint = "fair"
             elif 4 <= ctx_scale < 8:
-                ctx_quality_hint = 'poor'
-            else: # x8 or more
-                ctx_quality_hint = 'abysmal'
-            
-            if ctx_scale >= 2: # anything below 'good'
-                print_warning(
-                    f"context scale is x{ctx_scale} ({ctx_quality_hint})"
-                )
+                ctx_quality_hint = "poor"
+            else:  # x8 or more
+                ctx_quality_hint = "abysmal"
 
-        cpu_count = int(os.cpu_count()) # only read once
+            if ctx_scale >= 2:  # anything below 'good'
+                print_warning(f"context scale is x{ctx_scale} ({ctx_quality_hint})")
+
+        cpu_count = int(os.cpu_count())  # only read once
 
         if n_layer is not None and (n_gpu_layers >= n_layer or n_gpu_layers < 0):
             # if model is fully offloaded
@@ -203,19 +200,17 @@ class Model:
         else:
             # if model is not fully offloaded
             n_batch = 512
-        
+
         # these values for n_threads and n_threads_batch are known to
         # be optimal unless the host system has an unequal amount of
         # P-cores and E-cores
-        n_threads = max(cpu_count//2, 1)
+        n_threads = max(cpu_count // 2, 1)
         n_threads_batch = cpu_count
 
         if flash_attn and n_gpu_layers == 0:
-            print_warning(
-                "disabling flash_attn because n_gpu_layers == 0"
-            )
+            print_warning("disabling flash_attn because n_gpu_layers == 0")
             flash_attn = False
-        
+
         # guard against models with no rope_freq_base
         if rope_freq_base is None:
             rope_freq_base = 0
@@ -223,47 +218,41 @@ class Model:
         self.llama: Llama = Llama(
             model_path=model_path,
             n_ctx=self.context_length,
-            n_gpu_layers=n_gpu_layers,         # KV cache quantization is
-            use_mmap=True,                     # controlled by the `type_k`
-            use_mlock=False,                   # and `type_v` parameters.
-            logits_all=False,                  # not all combinations are
-            n_batch=n_batch,                   # supported.
-            n_threads=n_threads,               #
-            n_threads_batch=n_threads_batch,   # use `1` for f16 (default)
-            rope_freq_base=rope_freq_base,     # use `8` for q8_0
-            mul_mat_q=True,                    # use `7` for q5_1
-            offload_kqv=offload_kqv,           # use `6` for q5_0
-            flash_attn=flash_attn,             # use `3` for q4_1
-            #type_k=8,                         # use `2` for q4_0
-            #type_v=8,
-            verbose=verbose
+            n_gpu_layers=n_gpu_layers,  # KV cache quantization is
+            use_mmap=True,  # controlled by the `type_k`
+            use_mlock=False,  # and `type_v` parameters.
+            logits_all=False,  # not all combinations are
+            n_batch=n_batch,  # supported.
+            n_threads=n_threads,  #
+            n_threads_batch=n_threads_batch,  # use `1` for f16 (default)
+            rope_freq_base=rope_freq_base,  # use `8` for q8_0
+            mul_mat_q=True,  # use `7` for q5_1
+            offload_kqv=offload_kqv,  # use `6` for q5_0
+            flash_attn=flash_attn,  # use `3` for q4_1
+            # type_k=8,                         # use `2` for q4_0
+            # type_v=8,
+            verbose=verbose,
         )
 
         try:
-            self.vocab: list[str] = self.metadata['tokenizer.ggml.tokens']
+            self.vocab: list[str] = self.metadata["tokenizer.ggml.tokens"]
         except (KeyError, TypeError, ValueError):
             self.vocab = None
-            print_warning(
-                "could not set Model.vocab, defaulting to None"
-            )
+            print_warning("could not set Model.vocab, defaulting to None")
         try:
-            self.bos_token = int(self.metadata['tokenizer.ggml.bos_token_id'])
+            self.bos_token = int(self.metadata["tokenizer.ggml.bos_token_id"])
         except (KeyError, TypeError, ValueError):
             self.bos_token = int(self.llama.token_bos())
             if self.bos_token < 0:
                 self.bos_token = None
-                print_warning(
-                    "could not set Model.bos_token, defaulting to None"
-                )
+                print_warning("could not set Model.bos_token, defaulting to None")
         try:
-            self.eos_token = int(self.metadata['tokenizer.ggml.eos_token_id'])
+            self.eos_token = int(self.metadata["tokenizer.ggml.eos_token_id"])
         except (KeyError, TypeError, ValueError):
             self.eos_token = int(self.llama.token_eos())
             if self.eos_token < 0:
                 self.eos_token = None
-                print_warning(
-                    "could not set Model.eos_token, defaulting to None"
-                )
+                print_warning("could not set Model.eos_token, defaulting to None")
 
         # These special tokens are optional
         # if a negative value is returned as a token, it is not defined
@@ -271,52 +260,38 @@ class Model:
         if self.eot_token < 0:
             self.eot_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.eot_token, defaulting to None"
-                )
-        self.nl_token  = int(self.llama._model.token_nl())
+                print_verbose("could not set Model.eot_token, defaulting to None")
+        self.nl_token = int(self.llama._model.token_nl())
         if self.nl_token < 0:
             self.nl_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.nl_token, defaulting to None"
-                )
+                print_verbose("could not set Model.nl_token, defaulting to None")
         self.prefix_token = int(self.llama._model.token_prefix())
         if self.prefix_token < 0:
             self.prefix_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.prefix_token, defaulting to None"
-                )
+                print_verbose("could not set Model.prefix_token, defaulting to None")
         self.middle_token = int(self.llama._model.token_middle())
         if self.middle_token < 0:
             self.middle_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.middle_token, defaulting to None"
-                )
+                print_verbose("could not set Model.middle_token, defaulting to None")
         self.suffix_token = int(self.llama._model.token_suffix())
         if self.suffix_token < 0:
             self.suffix_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.suffix_token, defaulting to None"
-                )
+                print_verbose("could not set Model.suffix_token, defaulting to None")
         self.cls_token = int(self.llama._model.token_cls())
         if self.cls_token < 0:
             self.cls_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.cls_token, defaulting to None"
-                )
+                print_verbose("could not set Model.cls_token, defaulting to None")
         self.sep_token = int(self.llama._model.token_sep())
         if self.sep_token < 0:
             self.sep_token = None
             if verbose:
-                print_verbose(
-                    "could not set Model.sep_token, defaulting to None"
-                )
-        
+                print_verbose("could not set Model.sep_token, defaulting to None")
+
         # expose these values because they may be useful / informative
         self.filename: str = os.path.basename(model_path)
         self.n_ctx_train: int = n_ctx_train
@@ -325,7 +300,7 @@ class Model:
         self.flash_attn: bool = flash_attn
         self.n_vocab: int = len(self.vocab)
         self.n_layer: int = n_layer
-        self.n_gpu_layers: int = n_gpu_layers 
+        self.n_gpu_layers: int = n_gpu_layers
         self.ctx_scale: float = ctx_scale
 
         if verbose:
@@ -364,36 +339,38 @@ class Model:
                 print_verbose(f"self.cls_token       == {self.cls_token}")
             if self.sep_token is not None:
                 print_verbose(f"self.sep_token       == {self.sep_token}")
-    
+
     @staticmethod
     def _calculate_rope_freq_base(
-            n_ctx_train: int,
-            n_ctx_load: int,
-            rope_freq_base_train: Union[float, None]
-        ) -> float:
+        n_ctx_train: int, n_ctx_load: int, rope_freq_base_train: Union[float, None]
+    ) -> float:
         """
         Returns the rope_freq_base value at which model should be loaded
         """
-        assert_type(n_ctx_train, int, 'n_ctx_train', '_calculate_rope_freq_base')
-        assert_type(n_ctx_load, int, 'n_ctx_load', '_calculate_rope_freq_base')
-        assert_type(rope_freq_base_train, (float, NoneType),
-                    'rope_freq_base_train', '_calculate_rope_freq_base')
+        assert_type(n_ctx_train, int, "n_ctx_train", "_calculate_rope_freq_base")
+        assert_type(n_ctx_load, int, "n_ctx_load", "_calculate_rope_freq_base")
+        assert_type(
+            rope_freq_base_train,
+            (float, NoneType),
+            "rope_freq_base_train",
+            "_calculate_rope_freq_base",
+        )
 
         if n_ctx_load <= n_ctx_train:
             if rope_freq_base_train is None:
                 return 0.0
             else:
                 return rope_freq_base_train
-        
+
         if rope_freq_base_train in [0.0, None]:
             raise ValueError(
-                'unable to load model with greater than native '
-                f'context length ({n_ctx_load} > {n_ctx_train}) '
-                'because model does not specify rope_freq_base. '
-                f'try again with context_length <= {n_ctx_train}'
+                "unable to load model with greater than native "
+                f"context length ({n_ctx_load} > {n_ctx_train}) "
+                "because model does not specify rope_freq_base. "
+                f"try again with context_length <= {n_ctx_train}"
             )
-        
-        return ((n_ctx_load/n_ctx_train)**(2**(1/4)))*rope_freq_base_train
+
+        return ((n_ctx_load / n_ctx_train) ** (2 ** (1 / 4))) * rope_freq_base_train
 
         # traditional formula:
         #   return ctx_scale*rope_freq_base_train
@@ -402,39 +379,39 @@ class Model:
         # experimental formula B:
         #   return (ctx_scale**(2**(1/4)))*rope_freq_base_train
 
-    
     def __repr__(self) -> str:
-        return \
-            f"Model({self._model_path!r}, " + \
-            f"context_length={self._context_length}, " + \
-            f"n_gpu_layers={self._n_gpu_layers}, " + \
-            f"offload_kqv={self._offload_kqv}, "+ \
-            f"flash_attn={self._flash_attn}, " + \
-            f"verbose={self._verbose})"
-    
+        return (
+            f"Model({self._model_path!r}, "
+            + f"context_length={self._context_length}, "
+            + f"n_gpu_layers={self._n_gpu_layers}, "
+            + f"offload_kqv={self._offload_kqv}, "
+            + f"flash_attn={self._flash_attn}, "
+            + f"verbose={self._verbose})"
+        )
+
     def __sizeof__(self) -> int:
         return self._model_file_size_bytes
-    
+
     def __del__(self):
         self.unload()
-    
+
     def __enter__(self):
         return self
 
     def __exit__(self, *_):
         self.unload()
-    
+
     def __call__(
         self,
         prompt: Union[str, list[int]],
         stops: list[Union[str, int]] = [],
-        sampler: SamplerSettings = DefaultSampling
+        sampler: SamplerSettings = DefaultSampling,
     ) -> str:
         """
         `Model(...)` is a shorthand for `Model.generate(...)`
         """
         return self.generate(prompt, stops, sampler)
-    
+
     def _print_debug(self) -> None:
         try:
             assert_model_is_loaded(self)
@@ -445,22 +422,22 @@ class Model:
             raise exc from failed_assertion
         print(
             "Model: ---------------------------------------------------------",
-            file=sys.stderr
+            file=sys.stderr,
         )
         _print_debug(self)
         print(
             "Llama: ---------------------------------------------------------",
-            file=sys.stderr
+            file=sys.stderr,
         )
         _print_debug(self.llama)
         print(
             "_LlamaModel: ---------------------------------------------------",
-            file=sys.stderr
+            file=sys.stderr,
         )
         _print_debug(self.llama._model)
         print(
             "llama_model_p: -------------------------------------------------",
-            file=sys.stderr
+            file=sys.stderr,
         )
         _print_debug(self.llama._model.model)
 
@@ -468,29 +445,29 @@ class Model:
         """
         Unload the model from memory
         """
-        if not hasattr(self, 'llama'):
+        if not hasattr(self, "llama"):
             if self.verbose:
-                print_verbose('model already unloaded')
+                print_verbose("model already unloaded")
             return
-        
+
         if self.verbose:
-            print_verbose('unloading model...')
+            print_verbose("unloading model...")
 
         self.llama.close()
 
-        while hasattr(self, 'llama'):
-            delattr(self, 'llama')
+        while hasattr(self, "llama"):
+            delattr(self, "llama")
 
         if self.verbose:
-            print_verbose('model unloaded')
-    
+            print_verbose("model unloaded")
+
     def reload(
         self,
         context_length: Optional[int] = None,
         n_gpu_layers: Optional[int] = None,
         offload_kqv: Optional[bool] = None,
         flash_attn: Optional[bool] = None,
-        verbose: Optional[bool] = None
+        verbose: Optional[bool] = None,
     ):
         """
         Reload the model
@@ -500,7 +477,9 @@ class Model:
         self.unload()
         self.__init__(
             model_path=self._model_path,
-            context_length=self._context_length if context_length is None else context_length,
+            context_length=self._context_length
+            if context_length is None
+            else context_length,
             n_gpu_layers=self._n_gpu_layers if n_gpu_layers is None else n_gpu_layers,
             offload_kqv=self._offload_kqv if offload_kqv is None else offload_kqv,
             flash_attn=self._flash_attn if flash_attn is None else flash_attn,
@@ -514,20 +493,13 @@ class Model:
         including the appended BOS token.
         """
         assert_model_is_loaded(self)
-        return len(
-            self.llama.tokenize(
-                text.encode(
-                    "utf-8",
-                    errors="ignore"
-                )
-            )
-        )
+        return len(self.llama.tokenize(text.encode("utf-8", errors="ignore")))
 
     def generate(
         self,
         prompt: Union[str, list[int]],
         stops: list[Union[str, int]] = [],
-        sampler: SamplerSettings = DefaultSampling
+        sampler: SamplerSettings = DefaultSampling,
     ) -> str:
         """
         Given a prompt, return a generated string.
@@ -538,41 +510,40 @@ class Model:
         - stops: A list of strings and/or token IDs at which to end the generation early
         - sampler: The SamplerSettings object used to control text generation
         """
-        assert_type(prompt, (str, list), 'prompt', 'generate')
+        assert_type(prompt, (str, list), "prompt", "generate")
         if isinstance(prompt, list):
             for tok in prompt:
                 assert_type(
                     tok,
                     int,
-                    'some item in the list of prompt tokens',
-                    'generate',
+                    "some item in the list of prompt tokens",
+                    "generate",
                 )
-        assert_type(stops, list, 'stops', 'generate')
+        assert_type(stops, list, "stops", "generate")
         for item in stops:
-            assert_type(
-                item,
-                (str, int),
-                "some item in parameter 'stops'",
-                'generate'
-            )
+            assert_type(item, (str, int), "some item in parameter 'stops'", "generate")
 
         if self.verbose:
-            print_verbose(f'using the following sampler settings for Model.generate:')
-            print_verbose(f'max_len_tokens    == {sampler.max_len_tokens}')
-            print_verbose(f'temp              == {sampler.temp}')
-            print_verbose(f'top_p             == {sampler.top_p}')
-            print_verbose(f'min_p             == {sampler.min_p}')
-            print_verbose(f'frequency_penalty == {sampler.frequency_penalty}')
-            print_verbose(f'presence_penalty  == {sampler.presence_penalty}')
-            print_verbose(f'repeat_penalty    == {sampler.repeat_penalty}')
-            print_verbose(f'top_k             == {sampler.top_k}')
+            print_verbose(f"using the following sampler settings for Model.generate:")
+            print_verbose(f"max_len_tokens    == {sampler.max_len_tokens}")
+            print_verbose(f"temp              == {sampler.temp}")
+            print_verbose(f"top_p             == {sampler.top_p}")
+            print_verbose(f"min_p             == {sampler.min_p}")
+            print_verbose(f"frequency_penalty == {sampler.frequency_penalty}")
+            print_verbose(f"presence_penalty  == {sampler.presence_penalty}")
+            print_verbose(f"repeat_penalty    == {sampler.repeat_penalty}")
+            print_verbose(f"top_k             == {sampler.top_k}")
 
         stop_strs: list[str] = [stop for stop in stops if isinstance(stop, str)]
-        stop_token_ids: list[int] = [tok_id for tok_id in stops if isinstance(tok_id, int)]
+        stop_token_ids: list[int] = [
+            tok_id for tok_id in stops if isinstance(tok_id, int)
+        ]
         stopping_criteria = None
         if stop_token_ids is not []:
+
             def stop_on_token_ids(tokens, *args, **kwargs):
                 return tokens[-1] in stop_token_ids
+
             stopping_criteria = StoppingCriteriaList([stop_on_token_ids])
 
         assert_model_is_loaded(self)
@@ -587,17 +558,15 @@ class Model:
             repeat_penalty=sampler.repeat_penalty,
             top_k=sampler.top_k,
             stop=stop_strs,
-            stopping_criteria=stopping_criteria
-        )['choices'][0]['text']
-    
+            stopping_criteria=stopping_criteria,
+        )["choices"][0]["text"]
 
     def stream(
         self,
         prompt: Union[str, list[int]],
         stops: list[Union[str, int]] = [],
-        sampler: SamplerSettings = DefaultSampling
+        sampler: SamplerSettings = DefaultSampling,
     ) -> Generator:
-
         """
         Given a prompt, return a Generator that yields dicts containing tokens.
 
@@ -612,43 +581,39 @@ class Model:
         - sampler: The SamplerSettings object used to control text generation
         """
 
-        assert_type(prompt, (str, list), 'prompt', 'stream')
+        assert_type(prompt, (str, list), "prompt", "stream")
         if isinstance(prompt, list):
             for tok in prompt:
                 assert_type(
-                    tok,
-                    int,
-                    'some item in the list of prompt tokens',
-                    'stream'
+                    tok, int, "some item in the list of prompt tokens", "stream"
                 )
-        assert_type(stops, list, 'stops', 'stream')
+        assert_type(stops, list, "stops", "stream")
         for item in stops:
-            assert_type(
-                item,
-                (str, int),
-                "some item in parameter 'stops'",
-                'stream'
-            )
+            assert_type(item, (str, int), "some item in parameter 'stops'", "stream")
 
         if self.verbose:
-            print_verbose(f'using the following sampler settings for Model.stream:')
-            print_verbose(f'max_len_tokens    == {sampler.max_len_tokens}')
-            print_verbose(f'temp              == {sampler.temp}')
-            print_verbose(f'top_p             == {sampler.top_p}')
-            print_verbose(f'min_p             == {sampler.min_p}')
-            print_verbose(f'frequency_penalty == {sampler.frequency_penalty}')
-            print_verbose(f'presence_penalty  == {sampler.presence_penalty}')
-            print_verbose(f'repeat_penalty    == {sampler.repeat_penalty}')
-            print_verbose(f'top_k             == {sampler.top_k}')
-        
+            print_verbose(f"using the following sampler settings for Model.stream:")
+            print_verbose(f"max_len_tokens    == {sampler.max_len_tokens}")
+            print_verbose(f"temp              == {sampler.temp}")
+            print_verbose(f"top_p             == {sampler.top_p}")
+            print_verbose(f"min_p             == {sampler.min_p}")
+            print_verbose(f"frequency_penalty == {sampler.frequency_penalty}")
+            print_verbose(f"presence_penalty  == {sampler.presence_penalty}")
+            print_verbose(f"repeat_penalty    == {sampler.repeat_penalty}")
+            print_verbose(f"top_k             == {sampler.top_k}")
+
         stop_strs: list[str] = [stop for stop in stops if isinstance(stop, str)]
-        stop_token_ids: list[int] = [tok_id for tok_id in stops if isinstance(tok_id, int)]
+        stop_token_ids: list[int] = [
+            tok_id for tok_id in stops if isinstance(tok_id, int)
+        ]
         stopping_criteria = None
         if stop_token_ids is not []:
+
             def stop_on_token_ids(tokens, *args, **kwargs):
                 return tokens[-1] in stop_token_ids
+
             stopping_criteria = StoppingCriteriaList([stop_on_token_ids])
-        
+
         assert_model_is_loaded(self)
         return self.llama.create_completion(
             prompt,
@@ -662,9 +627,8 @@ class Model:
             top_k=sampler.top_k,
             stream=True,
             stop=stop_strs,
-            stopping_criteria=stopping_criteria
+            stopping_criteria=stopping_criteria,
         )
-
 
     def stream_print(
         self,
@@ -673,7 +637,7 @@ class Model:
         sampler: SamplerSettings = DefaultSampling,
         end: str = "\n",
         file: _SupportsWriteAndFlush = sys.stdout,
-        flush: bool = True
+        flush: bool = True,
     ) -> str:
         """
         Given a prompt, stream text to a file as it is generated, and return
@@ -689,24 +653,19 @@ class Model:
         - file: The file where text should be printed
         - flush: Whether to flush the stream after each token
         """
-        
-        token_generator = self.stream(
-            prompt=prompt,
-            stops=stops,
-            sampler=sampler
-        )
 
-        res = ''
+        token_generator = self.stream(prompt=prompt, stops=stops, sampler=sampler)
+
+        res = ""
         for i in token_generator:
-            tok = i['choices'][0]['text']
-            print(tok, end='', file=file, flush=flush)
+            tok = i["choices"][0]["text"]
+            print(tok, end="", file=file, flush=flush)
             res += tok
 
         # print `end`, and always flush stream after generation is done
-        print(end, end='', file=file, flush=True)
+        print(end, end="", file=file, flush=True)
 
         return res
-
 
     def ingest(self, text: Union[str, list[int]]) -> None:
         """
@@ -714,18 +673,10 @@ class Model:
         """
 
         assert_model_is_loaded(self)
-        self.llama.create_completion(
-            text,
-            max_tokens=1,
-            temperature=0.0
-        )
-    
+        self.llama.create_completion(text, max_tokens=1, temperature=0.0)
 
     def candidates(
-        self,
-        prompt: str,
-        k: int,
-        temp: Optional[float] = None
+        self, prompt: str, k: int, temp: Optional[float] = None
     ) -> list[tuple[str, np.floating]]:
         """
         Given prompt `str` and k `int`, return a sorted list of the
@@ -738,27 +689,27 @@ class Model:
         # TODO: this functions uses 7GB of memory
         # maybe switch from lists to numpy arrays?
 
-        assert_type(prompt, str, 'prompt', 'candidates')
-        assert_type(k, int, 'k', 'candidates')
-        assert_type(temp, (float, NoneType), 'temp', 'candidates')
+        assert_type(prompt, str, "prompt", "candidates")
+        assert_type(k, int, "k", "candidates")
+        assert_type(temp, (float, NoneType), "temp", "candidates")
         if not 1 <= k <= len(self.vocab):
             raise ValueError(
                 f"candidates: k should be between 1 and {len(self.vocab)} inclusive"
             )
 
         assert_model_is_loaded(self)
-        prompt_tokens = self.llama.tokenize(prompt.encode('utf-8', errors='ignore'))
-        self.llama.reset() # reset model state
+        prompt_tokens = self.llama.tokenize(prompt.encode("utf-8", errors="ignore"))
+        self.llama.reset()  # reset model state
         self.llama.eval(prompt_tokens)
         scores = self.llama.scores[len(prompt_tokens) - 1]
 
         # len(self.llama.scores) == self.context_length
         # len(self.llama.scores[i]) == len(self.vocab)
-        
+
         # normalize scores with softmax
         # must normalize over all logits, not just top k
         if self.verbose:
-            print_verbose(f'calculating softmax over {len(scores)} values')
+            print_verbose(f"calculating softmax over {len(scores)} values")
         normalized_scores: list[np.floating] = list(
             softmax(z=scores, T=temp, dtype=None)
         )
@@ -771,8 +722,7 @@ class Model:
             i += 1
 
         # return token_probs_list, sorted by probability, only top k
-        return heapq.nlargest(k, token_probs_list, key=lambda x:x[1])
-
+        return heapq.nlargest(k, token_probs_list, key=lambda x: x[1])
 
     def print_candidates(
         self,
@@ -807,28 +757,22 @@ def assert_model_is_loaded(model: Model) -> None:
         pass
 
     if model is None:
-        exc = ModelUnloadedException(
-            "model is None"
-        )
-    elif not hasattr(model, 'llama'):
-        exc = ModelUnloadedException(
-            "model has no attribute 'llama'"
-        )
-    elif not hasattr(model.llama, '_model'):
+        exc = ModelUnloadedException("model is None")
+    elif not hasattr(model, "llama"):
+        exc = ModelUnloadedException("model has no attribute 'llama'")
+    elif not hasattr(model.llama, "_model"):
         exc = ModelUnloadedException(
             "llama_cpp.Llama instance has no attribute '_model'"
         )
-    elif not hasattr(model.llama._model, 'model'):
+    elif not hasattr(model.llama._model, "model"):
         exc = ModelUnloadedException(
             "llama_cpp._internals._LlamaModel instance has no attribute 'model'"
         )
     elif model.llama._model.model is None:
-        exc = ModelUnloadedException(
-            "llama_cpp._internals._LlamaModel.model is None"
-        )
+        exc = ModelUnloadedException("llama_cpp._internals._LlamaModel.model is None")
     else:
-        exc = ModelUnloadedException(     # likely unreachable
+        exc = ModelUnloadedException(  # likely unreachable
             "model is not loaded"
         )
-    exc.add_note('Are you trying to use a model that has been unloaded?')
+    exc.add_note("Are you trying to use a model that has been unloaded?")
     raise exc

--- a/easy_llama/samplers.py
+++ b/easy_llama/samplers.py
@@ -1,17 +1,17 @@
 # samplers.py
 # https://github.com/ddh0/easy-llama/
-from ._version import __version__, __llama_cpp_version__
+from ._version import __llama_cpp_version__, __version__
 
 """Submodule containing SamplerSettings class and some preset samplers"""
 
+from sys import maxsize
 from typing import Optional
-from types  import NoneType
-from sys    import maxsize
 
+from .extra_types import NoneType
 from .utils import assert_type
 
-
 MAX_TEMP = float(maxsize)
+
 
 class SamplerSettings:
     """
@@ -24,26 +24,26 @@ class SamplerSettings:
     """
 
     param_types: dict[str, tuple[type]] = {
-        'max_len_tokens'    : (int, NoneType),
-        'temp'              : (float, NoneType),
-        'top_p'             : (float, NoneType),
-        'min_p'             : (float, NoneType),
-        'frequency_penalty' : (float, NoneType),
-        'presence_penalty'  : (float, NoneType),
-        'repeat_penalty'    : (float, NoneType),
-        'top_k'             : (int, NoneType)
+        "max_len_tokens": (int, NoneType),
+        "temp": (float, NoneType),
+        "top_p": (float, NoneType),
+        "min_p": (float, NoneType),
+        "frequency_penalty": (float, NoneType),
+        "presence_penalty": (float, NoneType),
+        "repeat_penalty": (float, NoneType),
+        "top_k": (int, NoneType),
     }
 
     def __init__(
         self,
-        max_len_tokens:    Optional[int]   = -1,
-        temp:              Optional[float] = 0.8,
-        top_p:             Optional[float] = 0.95,
-        min_p:             Optional[float] = 0.05,
+        max_len_tokens: Optional[int] = -1,
+        temp: Optional[float] = 0.8,
+        top_p: Optional[float] = 0.95,
+        min_p: Optional[float] = 0.05,
         frequency_penalty: Optional[float] = 0.0,
-        presence_penalty:  Optional[float] = 0.0,
-        repeat_penalty:    Optional[float] = 1.0,
-        top_k:             Optional[int]   = 40
+        presence_penalty: Optional[float] = 0.0,
+        repeat_penalty: Optional[float] = 1.0,
+        top_k: Optional[int] = 40,
     ):
         """
         Construct a new SamplerSettings instance
@@ -59,124 +59,84 @@ class SamplerSettings:
         For greedy decoding, see the preset `GreedyDecoding`.
         """
 
-        self.max_len_tokens    = max_len_tokens if max_len_tokens is not None else -1
-        self.temp              = temp if temp is not None else 1.0
-        self.top_p             = top_p if top_p is not None else 1.0
-        self.min_p             = min_p if min_p is not None else 0.0
-        self.frequency_penalty = frequency_penalty if frequency_penalty is not None else 0.0
-        self.presence_penalty  = presence_penalty if presence_penalty is not None else 0.0
-        self.repeat_penalty    = repeat_penalty if repeat_penalty is not None else 1.0
-        self.top_k             = top_k if top_k is not None else -1
+        self.max_len_tokens = max_len_tokens if max_len_tokens is not None else -1
+        self.temp = temp if temp is not None else 1.0
+        self.top_p = top_p if top_p is not None else 1.0
+        self.min_p = min_p if min_p is not None else 0.0
+        self.frequency_penalty = (
+            frequency_penalty if frequency_penalty is not None else 0.0
+        )
+        self.presence_penalty = (
+            presence_penalty if presence_penalty is not None else 0.0
+        )
+        self.repeat_penalty = repeat_penalty if repeat_penalty is not None else 1.0
+        self.top_k = top_k if top_k is not None else -1
 
         for sampler_param in SamplerSettings.param_types:
             assert_type(
                 getattr(self, sampler_param),
                 SamplerSettings.param_types[sampler_param],
-                f'{sampler_param} parameter',
-                'SamplerSettings'
+                f"{sampler_param} parameter",
+                "SamplerSettings",
             )
-    
+
     def __repr__(self) -> str:
-        return \
-            'SamplerSettings(' \
-            f'max_len_tokens={self.max_len_tokens}, ' \
-            f'temp={self.temp}, ' \
-            f'top_p={self.top_p}, ' \
-            f'min_p={self.min_p}, ' \
-            f'frequency_penalty={self.frequency_penalty}, ' \
-            f'presence_penalty={self.presence_penalty}, ' \
-            f'repeat_penalty={self.repeat_penalty}, ' \
-            f'top_k={self.top_k})'
+        return (
+            "SamplerSettings("
+            f"max_len_tokens={self.max_len_tokens}, "
+            f"temp={self.temp}, "
+            f"top_p={self.top_p}, "
+            f"min_p={self.min_p}, "
+            f"frequency_penalty={self.frequency_penalty}, "
+            f"presence_penalty={self.presence_penalty}, "
+            f"repeat_penalty={self.repeat_penalty}, "
+            f"top_k={self.top_k})"
+        )
+
 
 # most likely token is always chosen
 GreedyDecoding = SamplerSettings(
-    temp = 0.0,
+    temp=0.0,
 )
 
 # reflects llama.cpp
 DefaultSampling = SamplerSettings()
 
 # unmodified probability distribution (i.e. what the model actually thinks)
-SimpleSampling = SamplerSettings(
-    temp = 1.0,
-    top_p = 1.0,
-    min_p = 0.0,
-    top_k = -1
-)
+SimpleSampling = SamplerSettings(temp=1.0, top_p=1.0, min_p=0.0, top_k=-1)
 
 # reflects old llama.cpp defaults
-ClassicSampling = SamplerSettings(
-    min_p = 0.0,
-    repeat_penalty = 1.1
-)
+ClassicSampling = SamplerSettings(min_p=0.0, repeat_penalty=1.1)
 
 # halfway between DefaultSampling and SimpleSampling
-SemiSampling = SamplerSettings(
-    temp = 0.9,
-    top_p = 0.975,
-    min_p = 0.025,
-    top_k = 80
-)
+SemiSampling = SamplerSettings(temp=0.9, top_p=0.975, min_p=0.025, top_k=80)
 
 # for models with large vocabulary, which tend to run hot
-TikTokenSampling = SamplerSettings(
-    temp=0.6,
-    repeat_penalty=1.1
-)
+TikTokenSampling = SamplerSettings(temp=0.6, repeat_penalty=1.1)
 
 # use min_p as the only active sampler (more permissive)
-LowMinPSampling = SamplerSettings(
-    temp = 1.0,
-    top_p = 1.0,
-    min_p = 0.05,
-    top_k = -1
-)
+LowMinPSampling = SamplerSettings(temp=1.0, top_p=1.0, min_p=0.05, top_k=-1)
 
 # use min_p as the only active sampler (moderate)
-MinPSampling = SamplerSettings(
-    temp = 1.0,
-    top_p = 1.0,
-    min_p = 0.1,
-    top_k = -1
-)
+MinPSampling = SamplerSettings(temp=1.0, top_p=1.0, min_p=0.1, top_k=-1)
 
 # use min_p as the only active sampler (more restrictive)
-StrictMinPSampling = SamplerSettings(
-    temp = 1.0,
-    top_p = 1.0,
-    min_p = 0.2,
-    top_k = -1
-)
+StrictMinPSampling = SamplerSettings(temp=1.0, top_p=1.0, min_p=0.2, top_k=-1)
 
 # https://arxiv.org/abs/2210.14140
-ContrastiveSearch = SamplerSettings(
-    temp = 0.0,
-    presence_penalty = 0.6
-)
+ContrastiveSearch = SamplerSettings(temp=0.0, presence_penalty=0.6)
 
 # https://arxiv.org/abs/2210.14140
-WarmContrastiveSearch = SamplerSettings(
-    temp = 0.0,
-    presence_penalty = 1.0
-)
+WarmContrastiveSearch = SamplerSettings(temp=0.0, presence_penalty=1.0)
 
 # outputs completely random tokens from vocab (useless)
-RandomSampling = SamplerSettings(
-    temp = MAX_TEMP,
-    top_p = 1.0,
-    min_p = 0.0,
-    top_k = -1
-)
+RandomSampling = SamplerSettings(temp=MAX_TEMP, top_p=1.0, min_p=0.0, top_k=-1)
 
 # default sampling with reduced temperature
-LowTempSampling = SamplerSettings(
-    temp = 0.4
-)
+LowTempSampling = SamplerSettings(temp=0.4)
 
 # default sampling with increased temperature
-HighTempSampling = SamplerSettings(
-    temp = 1.2
-)
+HighTempSampling = SamplerSettings(temp=1.2)
 
 #
 # Samplers below this line are for specific models / model families
@@ -184,11 +144,11 @@ HighTempSampling = SamplerSettings(
 
 # https://huggingface.co/sophosympatheia/Midnight-Miqu-70B-v1.5
 MidnightMiqu = SamplerSettings(
-    temp = 1.0,
-    top_p = 1.0,
-    min_p = 0.12,
-    frequency_penalty = 0.0,
-    presence_penalty = 0.0,
-    repeat_penalty = 1.05,
-    top_k = -1
+    temp=1.0,
+    top_p=1.0,
+    min_p=0.12,
+    frequency_penalty=0.0,
+    presence_penalty=0.0,
+    repeat_penalty=1.05,
+    top_k=-1,
 )


### PR DESCRIPTION
I found that the only thing preventing this library from being used with Python 3.9 was the NoneType import. 3.9 is still pretty popular in the LLM / AI communities because of some other slow to update libraries so I thought this would be a worthwhile change so I am pulling this to allow you the choice.

[types.NoneType was added in 3.10](https://docs.python.org/3/library/types.html#types.NoneType).

Because it's part of my normal workflow I also ran `ruff format` and `ruff check --fix --select I` on the files I changed, there were a lot more changes than I expected from this. The files were previously VERY nicely formatted, but I am not sure what formatter was used. Perhaps a "contributing" section in the readme or adding a dev dependency for the formatting used would be good.

Weather you are interested in merging this or not, thank you for the library, it's great.